### PR TITLE
Increase width of the add/del bar

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -33,6 +33,10 @@ table.changes > tbody > tr > td:first-child {
 	padding-right: 1em;
 }
 
+table.changes > tbody > tr > td:nth-child(2) {
+    width: 3em;
+}
+
 .additions {
 	background-color: green;
 }


### PR DESCRIPTION
For big PRs, it's typically quite hard to see which files have the biggest changes. Also the nice bar is hardly visible in general.
This has been bothering me for a while now and I finally got around looking into it.
Preview:

![image](https://user-images.githubusercontent.com/4370550/35798208-5ec9e000-0a62-11e8-931e-de098ccd53fc.png)

What do you think? Even bigger?